### PR TITLE
Add the identifier for calls to addAnnotatedType

### DIFF
--- a/bval-jsr/src/main/java/org/apache/bval/cdi/BValExtension.java
+++ b/bval-jsr/src/main/java/org/apache/bval/cdi/BValExtension.java
@@ -109,7 +109,7 @@ public class BValExtension implements Extension {
 
     public void addBvalBinding(final @Observes BeforeBeanDiscovery beforeBeanDiscovery, final BeanManager beanManager) {
         beforeBeanDiscovery.addInterceptorBinding(BValBinding.class);
-        beforeBeanDiscovery.addAnnotatedType(beanManager.createAnnotatedType(BValInterceptor.class));
+        beforeBeanDiscovery.addAnnotatedType(beanManager.createAnnotatedType(BValInterceptor.class), "BValInterceptor");
     }
 
     // @WithAnnotations(ValidateOnExecution.class) doesn't check interfaces so not enough


### PR DESCRIPTION
Add identifier arg, as the method without it has been removed from the API in CDI 4.0