### PR TITLE
[BVAL-221] Jakarta Validation 3.1

### DIFF
--- a/.github/workflows/bval-ci.yml
+++ b/.github/workflows/bval-ci.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jdk: [ '11', '17', '21' ]
+        jdk: [ '17', '21' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@
 [![Build Status](https://github.com/apache/bval/workflows/BVal%20CI/badge.svg)](https://github.com/apache/bval/actions/workflows/bval-ci.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This is an implementation of the Java Bean Validation (JSRs 303, 349, 380) specification for Jakarta EE and Java SE.
+This is an implementation of the Jakarta Validation (JSRs 303, 349, 380) specification for Jakarta EE and Java SE.
 The technical objective is to provide a class level constraint declaration and validation facility for the Java application developer, as well as a constraint
 metadata repository and query API.
 See: https://beanvalidation.org/
 
 ## Branches
 
-### Master / 3.0.x
+### Master / 3.1.x
 
-Bean Validation 3.0 implementation
+Jakarta Validation 3.1 implementation
 
 ### 2.x
 
@@ -41,4 +41,6 @@ Bean Validation 1.x implementation
 
 ## Installation
 
+```shell
 mvn clean install
+```

--- a/bval-bundle/pom.xml
+++ b/bval-bundle/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.bval</groupId>
         <artifactId>bval-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <!-- use fully qualified naming for OSGi bundles -->

--- a/bval-extras/pom.xml
+++ b/bval-extras/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.bval</groupId>
         <artifactId>bval-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bval-extras</artifactId>

--- a/bval-jsr/pom.xml
+++ b/bval-jsr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.bval</groupId>
         <artifactId>bval-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bval-jsr</artifactId>

--- a/bval-jsr/pom.xml
+++ b/bval-jsr/pom.xml
@@ -209,8 +209,6 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper-el</artifactId>
-            <version>11.0.0-M21</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- TODO update to 6.0.0 once released -->

--- a/bval-jsr/pom.xml
+++ b/bval-jsr/pom.xml
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <version>4.0.1</version>
+            <version>4.1.0</version>
             <scope>provided</scope>
             <optional>true</optional>
             <exclusions>
@@ -178,14 +178,14 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>2.1.1</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.interceptor</groupId>
             <artifactId>jakarta.interceptor-api</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
           <scope>provided</scope>
         </dependency>
         <dependency>
@@ -209,9 +209,11 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper-el</artifactId>
-            <version>10.1.24</version>
+            <version>11.0.0-M21</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO update to 6.0.0 once released -->
         <dependency>
             <groupId>org.glassfish.expressly</groupId>
             <artifactId>expressly</artifactId>

--- a/bval-perf/pom.xml
+++ b/bval-perf/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-jasper-el</artifactId>
-        <version>10.1.24</version>
+        <version>11.0.0-M21</version>
         <scope>test</scope>
     </dependency>
 

--- a/bval-perf/pom.xml
+++ b/bval-perf/pom.xml
@@ -58,8 +58,6 @@
     <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-jasper-el</artifactId>
-        <version>11.0.0-M21</version>
-        <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/bval-perf/pom.xml
+++ b/bval-perf/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.bval</groupId>
     <artifactId>bval-parent</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>bval-perf</artifactId>

--- a/bval-tck/pom.xml
+++ b/bval-tck/pom.xml
@@ -132,8 +132,6 @@ under the License.
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper-el</artifactId>
-            <version>11.0.0-M21</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>

--- a/bval-tck/pom.xml
+++ b/bval-tck/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.bval</groupId>
         <artifactId>bval-parent</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bval-tck</artifactId>

--- a/bval-tck/pom.xml
+++ b/bval-tck/pom.xml
@@ -31,7 +31,7 @@ under the License.
     <description>Aggregates dependencies and runs the JSR-380 TCK</description>
 
     <properties>
-        <tck.version>3.0.1</tck.version>
+        <tck.version>3.1.1</tck.version>
         <owb.version>4.0.2</owb.version>
         <arquillian.version>1.8.0.Final</arquillian.version>
         <validation.provider>org.apache.bval.jsr.ApacheValidationProvider</validation.provider>
@@ -137,7 +137,7 @@ under the License.
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
-            <artifactId>beanvalidation-tck-tests</artifactId>
+            <artifactId>validation-tck-tests</artifactId>
             <version>${tck.version}</version>
             <scope>test</scope>
         </dependency>
@@ -196,7 +196,7 @@ under the License.
                                     <artifactItems>
                                         <artifactItem>
                                             <groupId>jakarta.validation</groupId>
-                                            <artifactId>beanvalidation-tck-tests</artifactId>
+                                            <artifactId>validation-tck-tests</artifactId>
                                             <type>xml</type>
                                             <classifier>suite</classifier>
                                             <overWrite>false</overWrite>
@@ -212,7 +212,7 @@ under the License.
                         <configuration>
                             <argLine>-Duser.language=en --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                             <suiteXmlFiles>
-                                <suiteXmlFile>${project.build.directory}/dependency/beanvalidation-tck-tests-suite.xml</suiteXmlFile>
+                                <suiteXmlFile>${project.build.directory}/dependency/validation-tck-tests-suite.xml</suiteXmlFile>
                             </suiteXmlFiles>
                             <systemProperties>
                                 <property>
@@ -276,7 +276,7 @@ under the License.
                                     <artifactItems>
                                         <artifactItem>
                                             <groupId>jakarta.validation</groupId>
-                                            <artifactId>beanvalidation-tck-tests</artifactId>
+                                            <artifactId>validation-tck-tests</artifactId>
                                             <version>${tck.version}</version>
                                             <type>jar</type>
                                             <overWrite>false</overWrite>
@@ -305,11 +305,25 @@ under the License.
                                 jakarta.validation.constraintvalidation,jakarta.validation.executable,jakarta.validation.groups,
                                 jakarta.validation.metadata,jakarta.validation.spi,jakarta.validation.valueextraction
                             </packages>
-                            <sigfile>${project.build.directory}/api-signature/validation-api-java8.sig</sigfile>
+                            <sigfile>${project.build.directory}/api-signature/validation-api-jdk17.sig</sigfile>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
+
+    <!-- TODO remove once validation TCK is released and synced to maven central -->
+    <repositories>
+        <repository>
+            <id>jakarta-oss-staging</id>
+            <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/bval-tck/pom.xml
+++ b/bval-tck/pom.xml
@@ -52,13 +52,13 @@ under the License.
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <version>4.0.1</version>
+            <version>4.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>2.1.1</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -88,7 +88,7 @@ under the License.
         <dependency>
             <groupId>jakarta.interceptor</groupId>
             <artifactId>jakarta.interceptor-api</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -132,7 +132,7 @@ under the License.
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper-el</artifactId>
-            <version>10.1.24</version>
+            <version>11.0.0-M21</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <artifactId>bval-parent</artifactId>
     <name>Apache BVal</name>
     <packaging>pom</packaging>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
 
     <description>Apache BVal parent pom</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -357,11 +357,18 @@
                 <scope>provided</scope>
             </dependency>
 
+            <!-- TODO upgrade to 11.0.x once released -->
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-el-api</artifactId>
-                <version>11.0.0-M21</version>
+                <version>10.1.25</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat</groupId>
+                <artifactId>tomcat-jasper-el</artifactId>
+                <version>10.1.25</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -356,17 +356,7 @@
                 <version>${commons.weaver.version}</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>com.thoughtworks.xstream</groupId>
-                <artifactId>xstream</artifactId>
-                <version>1.4.20</version>
-            </dependency>
-            <!-- Optional - only used by bval-json -->
-            <dependency>
-                <groupId>org.freemarker</groupId>
-                <artifactId>freemarker</artifactId>
-                <version>2.3.32</version>
-            </dependency>
+
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-el-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -325,14 +325,9 @@
             <dependency>
                 <groupId>jakarta.validation</groupId>
                 <artifactId>jakarta.validation-api</artifactId>
-                <version>3.0.2</version>
+                <version>3.1.0</version>
             </dependency>
-            <!-- Optional profile to use Spec RI API -->
-            <dependency>
-                <groupId>jakarta.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>2.0.1.Final</version>
-            </dependency>
+
             <!-- JPA2 spec required for JPA TraversableResolver support -->
             <dependency>
                 <groupId>jakarta.persistence</groupId>
@@ -375,7 +370,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-el-api</artifactId>
-                <version>10.1.24</version>
+                <version>11.0.0-M21</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -412,8 +412,8 @@
                             <manifestEntries>
                                 <Built-By>${built.by}</Built-By>
                                 <Implementation-Build>${buildNumber}</Implementation-Build>
-                                <Specification-Title>Bean Validation</Specification-Title>
-                                <Specification-Version>2.0</Specification-Version>
+                                <Specification-Title>Jakarta Validation</Specification-Title>
+                                <Specification-Version>3.1</Specification-Version>
                             </manifestEntries>
                         </archive>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <release>11</release>
+                        <release>17</release>
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>
                 </plugin>
@@ -474,22 +474,6 @@
                             <Bundle-DocURL>${project.url}</Bundle-DocURL>
                         </instructions>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>ianal-maven-plugin</artifactId>
-                    <version>1.0-alpha-1</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>verify-legal-files</goal>
-                            </goals>
-                            <configuration>
-                                <!-- Fail the build if any artifacts are missing legal files -->
-                                <strict>true</strict>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.rat</groupId>
@@ -609,11 +593,8 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <requireMavenVersion>
-                                    <version>[2.2.1,)</version>
-                                </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[1.8,)</version>
+                                    <version>[17,)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -627,10 +608,6 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>ianal-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -713,29 +690,5 @@
         <module>bval-bundle</module>
         <module>bval-perf</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>jdk16+</id>
-
-            <activation>
-                <jdk>[16,)</jdk>
-            </activation>
-
-            <!-- IANAL plugin is broken on jdk 16+ because of JEP 396 -->
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>ianal-maven-plugin</artifactId>
-
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
 </project>


### PR DESCRIPTION
Moves BVal to Jakarta Validation 3.1:
- Updates the API, TCK and dependencies on other Jakarta EE specs
- Raising compile level to Java 17
  - I dropped the long abandoned IANAL plugin, it doesn't work on Java 16+ anyways
- Document Jakarta Validation 3.1 compatibility

IMO we should really discuss if doing a hard cut like this is the right way, to my surprise absolutely no code changes are needed to be 3.1 compatible. Maybe adding a bval-tck31 module to claim compatibility with both Jakarta Bean Validation 3.0 and Jakarta Validation 3.1 at the same time might be a more suitable option?