### PR TITLE
Rely more on AnnotedTypes in CDI Extension again

### DIFF
--- a/bval-jsr/src/test/java/org/apache/bval/cdi/CdiConstraintOnlyOnParentClassTest.java
+++ b/bval-jsr/src/test/java/org/apache/bval/cdi/CdiConstraintOnlyOnParentClassTest.java
@@ -16,13 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.bval.jsr.cdi;
+package org.apache.bval.cdi;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.constraints.NotNull;
-import org.apache.bval.cdi.BValExtension;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;


### PR DESCRIPTION
For the related discussion see https://lists.apache.org/thread/3py3htgx0l4bd46tsd90l138xqy65s7t

@rmannibucau sorry it took me a bit to get back on this but please take a look if this is what you had in mind. I'm not really sure how I should read type hierarchy from AnnotatedTypes, all ways I found to do that lead through `java.lang.reflect.*` land